### PR TITLE
Fixing allowedChannels check

### DIFF
--- a/src/commands/dispatcher.js
+++ b/src/commands/dispatcher.js
@@ -46,7 +46,7 @@ export default class CommandDispatcher extends EventEmitter {
 		if(!this.bot.config.values.selfbot && message.guild
 			&& Module.isEnabled(this.bot.storage.settings, message.guild, 'channels')
 			&& !this.bot.storage.allowedChannels.isEmpty(message.guild)
-			&& !this.bot.storage.allowedChannels.exists(message.guild, message.channel.id)
+			&& !this.bot.storage.allowedChannels.find(message.guild, message.channel.id)
 			&& !this.bot.permissions.isAdmin(message.guild, message.author)) return null;
 
 		// Make sure the user isn't blacklisted


### PR DESCRIPTION
Removing reference to method bot.storage.allowedChannels.exists(), which (ironically) does not exist, replacing with bot.storage.allowedChannels.find(), which does exist